### PR TITLE
Porting SDL to QNX700 and Automotive Grade Linux (AGL) x64 platforms

### DIFF
--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -34,18 +34,13 @@ In order to create automation testing for additional platforms we need to make f
 POSIX (Portable Operating System Interface for Unix) is simply a set of standards that define how to develop programs for UNIX (and its variants). Being POSIX-compliant for an OS means that it supports those standards (e.g., APIs), and thus can either natively run UNIX programs, or at least porting an application from UNIX to the target OS is easy/easier than if it did not support POSIX. 
 
 Integration of SDL to the POSIX-certified (QNX) and mostly POSIX-compliant operation system (AGL) requires significant rework of SDL code.
-This proposal aims to minimize efforts of OEM manufacturers for SDL integration for QNX and AGL.
-
-POSIX complience des not means QNX complience. 
-POSIX complience is not enought for  certificatation leads to bugs when we integrate to production platform and we want to minimize incompatibilities 
-
-
-**QNX 6.5** (currently supported by SDL) is already out of date. New version of QNX released is QNX7.0.  
+This proposal aims to minimize efforts of OEM manufacturers for SDL integration on production QNX and AGL platforms. The efforts minimization will be achieved by minimization platform related SDL core code incompatibilities.
 
 **QNX 7.0** is widely used by OEM manufactures, so SDL should be ready to certify QNX7.0 for working on it. 
 
 **Automotive Grade Linux (AGL)** is modern and popular Linux platform for the Automotive industry. It is already used by many car manufacturers. 
-  SDL should also be ready to certify using this platform and to be tested on it. 
+
+SDL should also be ready to certify using these platforms and to be tested on them. 
 
 ## Proposed solution
 
@@ -59,25 +54,25 @@ It is the Project Maintainer responsibility to certify solution for all referenc
 
 ### Versions of platforms
 
-This proposal is about certifying of the current long term supported releases of Ubuntu, QNX, AGL for SDL to work on these platforms. 
+This proposal is about certifying of the current long term supported releases of Ubuntu, QNX, AGL for SDL Core to work on these platforms. 
 
 Current stable releases at the moment of proposal creation are: 
  - Ubuntu - 16.04 (x64) default
  - QNX - 7.0 (x64)
  - Automotive Grade Linux - Flounder 6.0.2 (x64)
  
-Future releases of referenced platforms will require new SDL-evolution proposal.
+Future releases of referenced platforms will require new SDL-evolution proposals.
 
 ### SDL compilation process:
 
-As part of this proposal we are *recomending* the folowing compilation process : 
+As part of this proposal we are *recommending* the following compilation process:
 
 #### Compilation for QNX 7.0
 
 Compilation for QNX 7.0 requires pre-installed QXN7.0 SDP on developer workstation.
 
 SDL will contain QNX 7.0 toolchain file that should be used for compilation.  
-Before compilation suggested to setup `THIRD_PARTY_LIBRARY_PATH` variable to avoid instalation of qnx libraries to host system
+Before compilation suggested to setup `THIRD_PARTY_LIBRARY_PATH` variable to avoid installation of QNX libraries to the host system.
 
 Example:  
 ```$ export THIRD_PARTY_LIBRARY_PATH=<third_party_path>```  
@@ -88,10 +83,10 @@ Then all binaries and libraries required for SDL run on QNX will be created in `
 
 ##### Compilation in docker container
 
-SDL will contain Docker file with environment ready for qnx compilation. This environment will not contain QNX SDP.
-Before compilation developer should provide path to SDP with directory mounted to container.
+SDL will contain a Docker file with environment ready for QNX compilation. This environment will not contain QNX Software Development Platform (SDP).
+Before compilation developer should provide path to the SDP with directory mounted to the container.
 
-Example of compilation with docker: 
+Example of compilation with a Docker file: 
 ```
 $ docker build -t  qnx_sdl_compile .
 $ docker run -v <sdl_core>:/home/developer/sdl \
@@ -102,13 +97,13 @@ Then all binaries and libraries, which are required for running SDL Core on the 
 
 #### Compilation for AGL 
 
-Compilation for AGL requires pre-installed AGL SDK on the developer platform. 
+Compilation for AGL requires pre-installed AGL Software Development Kit (SDK) on the developer platform. 
 Compilation for AGL is not cross-platform compilation, but specific versions of libraries should be guaranteed.
 
-SDL will contain Docker file with environment ready for SDL compilation on **AGL Flounder 6.0.2**.
-Before running compilation in container developer should specify source directory of SDL Core code.
+SDL will contain a Docker file with environment ready for SDL compilation on **AGL Flounder 6.0.2**.
+Before running compilation in the container, developer should specify source directory of SDL Core code.
 
-Compilation of SDL code for AGL will be done by using docker file(default way)
+Compilation of SDL Core code for AGL will be done by using docker file (default way):
 ```
 $ docker build -t agl_compile .
 $ docker run -v <sdl_core>:/home/developer/sdl agl_compile

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -9,28 +9,32 @@
 
 ## Introduction
 
-This proposal is about expanding the list of officially certified platforms by SDL with the following the operation systems:
+This proposal is about expanding the list of officially certified platforms by SDL with the following operation systems:
 
  - QNX 7.0 (x64)
  - Automotive Grade Linux (AGL) Flounder 6.0.2 (x64)
 
-And approach for cross-platform testing automation.
+The next part of this proposal is an approach for cross-platform testing automation.
 
-SDL source code should be compilable for the following platforms:
+SDL source code should be compilable on the following platforms:
 
  - Ubuntu - 16.04 (x64) default
  - QNX - 7.0 (x64)
  - Automotive Grade Linux - Flounder 6.0.2 (x64)
 
-Platform specific code should be isolated and should not contain any business logic. SDL sources should not contain code duplication for specific platform. SDL should not contain special pre-compiled binaries for specific platform.
+The following conditions must be matched: 
+- Platform specific code should be isolated and should not contain any business logic. 
+- SDL sources should not contain code duplication for specific platform.
+- SDL should not contain special pre-compiled binaries for specific platform.
 
 ## Motivation
 
 **QNX 6.5** (currently supported by SDL) is already out of date. New version of QNX released is QNX7.0.  
 
-**QNX 7.0** is widely used by OEM manufactures, so SDL should be ready to be certified for working on QNX7.0. 
+**QNX 7.0** is widely used by OEM manufactures, so SDL should be ready to certify QNX7.0 for working on it. 
 
-**Automotive Grade Linux (AGL)** is modern and popular Linux platform for the Automotive industry, and it is already used by many car manufacturers. SDL should also be ready to be certified for using this platform and tested on it. 
+**Automotive Grade Linux (AGL)** is modern and popular Linux platform for the Automotive industry. It is already used by many car manufacturers. 
+  SDL should also be ready to certify using this platform and to be tested on it. 
 
 ## Proposed solution
 
@@ -40,20 +44,27 @@ Provide readiness for open source SDL compilation and certification by SDL Steer
  - QNX 7.0 x64 (Using SDL on virtual workstation).
  - Automotive Grade Linux x64 (Using SDL on virtual workstation).
  
-Within continuous integration each change (Pull Request to develop) for SDL Core should be tested (in automated mode) for Ubuntu, QNX, AGL. It is the Project Maintainer responsibility to certify solution for all referenced platforms.
+Within continuous integration each change (Pull Request to develop) to SDL Core should be tested (in automated mode) for Ubuntu, QNX, AGL. 
+It is the Project Maintainer responsibility to certify solution for all referenced platforms.
 
 ### Versions of platforms
 
-This proposal is about certifying SDL for the latest releases of Ubuntu, QNX, AGL. 
+This proposal is about certifying of the current stable releases of Ubuntu, QNX, AGL for SDL to work on these platforms. 
+
+Current stable releases at the moment of proposal creation are: 
+ - Ubuntu - 16.04 (x64) default
+ - QNX - 7.0 (x64)
+ - Automotive Grade Linux - Flounder 6.0.2 (x64)
+ 
 Future releases of referenced platforms will require new SDL-evolution proposal.
 
 ### SDL compilation process:
 
 #### Compilation for QNX 7.0
 
-Compilation for QNX 7.0 required pre-installed QXN7.0 SDP on developer workstation.
+Compilation for QNX 7.0 requires pre-installed QXN7.0 SDP on developer workstation.
 
-SDL will contains QNX 7.0 toolchain file that should be used for compilation. 
+SDL will contain QNX 7.0 toolchain file that should be used for compilation. 
 Before compilation suggested to setup `THIRD_PARTY_LIBRARY_PATH` variable to avoid instalation of qnx libraries to host system
 
 Example : 
@@ -61,12 +72,12 @@ Example :
 ```$ cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>```
 ```$ make install```
 
-Then all binaries and libraries required for running SDL on QNX will be in `<build_dir>/bin` and <third_party_path>. 
+Then all binaries and libraries required for SDL run on QNX will be created in `<build_dir>/bin` and <third_party_path>. 
 
 ##### Compilation in docker container
 
-SDL will contain Docker file with environment ready for qnx compilaiton. This environment will not contain QNX SDP.
-Before compilation developer should provide path to SDP with cmounted to container directory.
+SDL will contain Docker file with environment ready for qnx compilation. This environment will not contain QNX SDP.
+Before compilation developer should provide path to SDP with directory mounted to container.
 
 Example of compilation with docker : 
 ```
@@ -79,14 +90,13 @@ Then all binaries and libraries, which are required for running SDL Core on the 
 
 #### Compilation for AGL 
 
-Compilation for AGL required pre-installed AGL SDK on the developer platform. 
-Compilation for AGL is not cross platform compilation, but specific versions of libraries should be guaranteed.
+Compilation for AGL requires pre-installed AGL SDK on the developer platform. 
+Compilation for AGL is not cross-platform compilation, but specific versions of libraries should be guaranteed.
 
-SDL will contains Docker file with environment ready for compilation for **AGL Flounder 6.0.2**.
-Default command for this Docker file will be `cmake && make install` commands that will compile SDL Core code.
+SDL will contain Docker file with environment ready for SDL compilation on **AGL Flounder 6.0.2**.
 Before running compilation in container developer should specify source directory of SDL Core code.
 
-Compilation of SDL code for AGL will be done by using docker file.
+Compilation of SDL code for AGL will be done by using docker file(default way)
 ```
 $ docker build -t agl_compile .
 $ docker run -v <sdl_core>:/home/developer/sdl agl_compile
@@ -112,7 +122,7 @@ These libraries should be ported and pre-installed on the distributed target pla
 
 #### Modification in Utils component
 
-Utils component will be affected by modification of SDL Core to providing ability to pass SDLC certification. 
+Utils component will be affected by modification of SDL Core providing ability to pass SDLC certification. 
 Utils component provides all SDL layers platform agnostic interface for communication with the operation system:
  - file system operations;
  - threads and sync primitives;
@@ -128,9 +138,9 @@ should be used for checking SDL functionality on the new platforms.
 
 #### Modifications in ATF
 
-sdl_atf tool should be executed on host workstation, but SDL will be ran on remote virtual workstation. 
+sdl_atf tool should be executed on host workstation, but SDL will be run on remote virtual workstation. 
 
-For support remote automated testing of SDL, the following proposal should be implemented: https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md
+For support of SDL remote automated testing, the following proposal should be implemented: https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md
 
 #### Modifications in the test scripts
 
@@ -143,12 +153,12 @@ The following items should be checked for all these platforms:
  
  - Compilation;
  - Unit tests;
- - Automated smoke;
+ - Automated smoke tests;
  - Existing features automated test cases (in case if feature is applicable on the virtual workstation).  
 
-SDL could be tested on virtual workstation for each mentioned platform. 
-For communication with mobile will be used **only**  Transmission Control Protocol (TCP) transport.
-For communication with HMI will be used TCP/WebSockets transport.
+SDL can be tested on virtual workstation for each mentioned platform. 
+**Only** Transmission Control Protocol (TCP) transport will be used for communication with mobile.
+TCP/WebSockets transport will be used for communication with HMI.
 
 All mentioned platforms (Ubuntu, AGL, QNX) will share codebase for communication with mobile and HMI.  
 
@@ -161,22 +171,22 @@ Mobile application may be connected to SDL Core via TCP.
 
 ### Automated testing.
 
-With some changes in ATF test framework and existing scripts SDL Core could be tested automatically on all 3 platforms. 
+SDL Core can be tested automatically on all 3 platforms with some changes in ATF test framework and existing scripts. 
 
-The same test scripts will be executed for: 
+The same test scripts will be executed for the following platforms: 
  - Ubuntu;
  - AGL;
  - QNX.
  
 Test coverage will include:
   - smoke testing of SDL Core (basic SDL scenarios and 3 policy flows (HTTP, PROPRIETARY, EXTERNAL_PROPRIETARY)); 
-  - all delivered features that are applicable for cross platform testing.
+  - all delivered features which are applicable for cross-platform testing.
   
 Each further delivered feature should be tested on all mentioned platforms.
 
 #### Missed functionality on AGL and QNX
 
-Open source SDL will no implement platform specific functionality on all mentioned systems.
+Open source SDL will not implement platform specific functionality on all mentioned systems.
 It is OEM's responsibility to implement and check platform specific layer of SDL - OEM Adapter. 
 
 This layer includes:
@@ -187,8 +197,8 @@ This layer includes:
 
 ## Potential downsides
 
-* Compilation for additional platfroms requires tricky changes in configuration and build files.
-* Futher changes of configuration or build files may breake ability to build SDL for QNX or AGL. 
+* Compilation for additional platforms requires tricky changes in configuration and build files.
+* Further changes of configuration or build files may breake ability to build SDL for QNX or AGL. 
 
 ## Impact on existing code
 
@@ -197,14 +207,14 @@ All components that use **utils** will be affected and need to be retested on th
  
 ## Alternatives considered
 
-#### Refactor cmake structure for easy multiple platforms support 
-Current approach for creating cmake files and mamaging dependencies have folowing problems : 
+#### Refactor cmake files structure for easy multiple platforms support 
+Current approach for creating cmake files and managing dependencies have the folowing problems : 
 
 1. Existing cmake structure does not allow easy and seamless integration to other operating systems.
 2. Existing cmake structure has no unified management system of 3rd party libraries.
-3. With existing cmake structure we have problems with components and libraries dependencies.
+3. Existing cmake structure does not allow flexible and clear dependencies resolution between components and libraries.
 
-Unificaiton of 3rd party libraries managment and internal dependencies management would reduce OEM efforts to integrate SDL into the custom OEM environment. 
+Unification of 3rd party libraries management and internal dependencies management would reduce OEM efforts to integrate SDL into the custom OEM environment. 
 
 #### Using real hardware with QNX and AGL
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -16,7 +16,7 @@ This proposal is about expanding the list of officially certified platforms by S
 
 In order to certify the above platforms for SDL, automation testing need to be created for additional platforms.
 
-In order to create automation testing for additional platforms we need to make folowing changes :
+In order to create automation testing for additional platforms we need to make following changes :
 
 1. SDL source code should be compilable on the following platforms:
 
@@ -31,9 +31,9 @@ In order to create automation testing for additional platforms we need to make f
 
 ## Motivation
 
-POSIX (Portable Operating System Interface for Unix) is simply a set of standards that define how to develop programs for UNIX (and its variants). Being POSIX-compliant for an OS means that it supports those standards (e.g., APIs), and thus can either natively run UNIX programs, or at least porting an application from UNIX to the target OS is easy/easier than if it did not support POSIX. 
+POSIX (Portable Operating System Interface for Unix) is simply a set of standards that defines how to develop programs for UNIX (and Unix-like variants). Being POSIX-compliant for an operating system (OS) means that it supports those standards (e.g., APIs), and thus can either natively run UNIX programs, or at least port an application from UNIX to the target OS. 
 
-Integration of SDL to the POSIX-certified (QNX) and mostly POSIX-compliant operation system (AGL) requires significant rework of SDL code.
+Integration of SDL to the POSIX-certified (QNX) and mostly POSIX-compliant operating system (AGL) requires significant rework of SDL code.
 This proposal aims to minimize efforts of OEM manufacturers for SDL integration on production QNX and AGL platforms. The efforts minimization will be achieved by minimization platform related SDL core code incompatibilities.
 
 **QNX 7.0** is widely used by OEM manufactures, so SDL should be ready to certify QNX7.0 for working on it. 
@@ -79,7 +79,7 @@ Example:
 ```$ cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>```  
 ```$ make install```
 
-Then all binaries and libraries required for SDL run on QNX will be created in `<build_dir>/bin` and <third_party_path>. 
+Then all binaries and libraries required for SDL run on QNX will be created in `<build_dir>/bin` and `<third_party_path>`. 
 
 ##### Compilation in docker container
 
@@ -100,7 +100,7 @@ Then all binaries and libraries, which are required for running SDL Core on the 
 Compilation for AGL requires pre-installed AGL Software Development Kit (SDK) on the developer platform. 
 Compilation for AGL is not cross-platform compilation, but specific versions of libraries should be guaranteed.
 
-SDL will contain a Docker file with environment ready for SDL compilation on **AGL Flounder 6.0.2**.
+SDL will contain a Docker file with environment ready for SDL compilation on **AGL Flounder 6.0.2**.  
 Before running compilation in the container, developer should specify source directory of SDL Core code.
 
 Compilation of SDL Core code for AGL will be done by using docker file (default way):
@@ -131,14 +131,14 @@ These libraries should be ported and pre-installed on the distributed target pla
 
 Utils component will be affected by modification of SDL Core and providing ability to pass SDLC certification.
 
-Utils component provides all SDL layers platform agnostic interface for communication with the operation system:
+Utils component provides all SDL layers platform agnostic interface for communication with the operating system:
  - file system operations;
  - threads and sync primitives;
  - timers;
  - logging;
  - system resource collecting.
  
- Currently Utils component is platform agnostic but it may require some minor modification in scope of compilation for QNX anf AGL.
+ Currently Utils component is platform agnostic but it may require some minor modification in scope of compilation for QNX and AGL.
  
 
 ### Provide ability for automated testing 
@@ -156,7 +156,7 @@ For support of the SDL remote automated testing, the following proposal should b
 #### Modifications in the test scripts
 
 Some scripts should be modified to use SDL on remote workstation.  
-All operations with SDL files ( hmi_capabilities, Preloaded Policy Table, etc ...) should be covered with wrappers that support either local or remote execution. 
+All operations with SDL files (hmi_capabilities, Preloaded Policy Table, etc.) should be covered with wrappers that support either local or remote execution. 
 
 ## Testing Approach
 
@@ -165,7 +165,7 @@ The following items should be checked for all these platforms:
  - Compilation;
  - Unit tests;
  - Automated smoke tests;
- - Automated test cases for validation of the existing features (in case if feature is applicable on the [virtual workstation](https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md)). 
+ - Automated test cases for validation of the existing features (in case the feature is applicable on the [virtual workstation](https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md)). 
 
 SDL can be tested on virtual workstation for each mentioned platform.  
 **Only** Transmission Control Protocol (TCP) transport will be used for communication with mobile.  
@@ -184,7 +184,7 @@ Mobile application may be connected to SDL Core via TCP.
 
 SDL Core can be tested automatically on all 3 platforms with some changes in ATF test framework and existing scripts. 
 
-The same test suite will be executed for the following platforms: 
+The same test suites will be executed for the following platforms: 
  - Ubuntu;
  - AGL;
  - QNX.
@@ -193,7 +193,7 @@ Test coverage will include:
   - smoke testing of SDL Core (basic SDL scenarios and 3 policy flows (HTTP, PROPRIETARY, EXTERNAL_PROPRIETARY)); 
   - all delivered features which are applicable for cross-platform testing.
   
-Each further delivered feature should be tested on all mentioned platforms.
+Each subsequent delivered feature should be tested on all mentioned platforms.
 
 #### Missed functionality on AGL and QNX
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -54,12 +54,28 @@ Future releases of referenced platforms will require new SDL-evolution proposal.
 Compilation for QNX 7.0 required pre-installed QXN7.0 SDP on developer workstation.
 
 SDL will contains QNX 7.0 toolchain file that should be used for compilation. 
-Example : 
+Before compilation suggested to setup `THIRD_PARTY_LIBRARY_PATH` variable to avoid instalation of qnx libraries to host system
 
+Example : 
+```$ export THIRD_PARTY_LIBRARY_PATH=<third_party_path>```
 ```$ cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>```
 ```$ make install```
 
-Then all binaries and libraries required for running SDL on QNX will be in `<build_dir>/bin`
+Then all binaries and libraries required for running SDL on QNX will be in `<build_dir>/bin` and <third_party_path>. 
+
+##### Compilation in docker container
+
+SDL will contain Docker file with environment ready for qnx compilaiton. This environment will not contain QNX SDP.
+Before compilation developer should provide path to SDP with cmounted to container directory.
+
+Example of compilation with docker : 
+```
+$ docker build -t  qnx_sdl_compile .
+$ docker run -v <sdl_core>:/home/developer/sdl \
+             -v <path_to_qnx_sdp>:/opt/qnx700 \
+             qnx_sdl_compile
+```
+Then all binaries and libraries, which are required for running SDL Core on the QNX platform will be stored in `<sdl_core>/build/bin` 
 
 #### Compilation for AGL 
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -40,21 +40,20 @@ Provide readiness for open source SDL compilation and certification by SDL Steer
  - QNX 7.0 x64 (Using SDL on virtual workstation).
  - Automotive Grade Linux x64 (Using SDL on virtual workstation).
  
-Within continious integraiton each change (Pull requests to develop) in SDL should be tested(in automated mode) for Ubuntu, QNX, AGL.
-It is the Project mainteiners responcibility to certify solution for all referenced platforms.
+Within continuous integration each change (Pull Request to develop) for SDL Core should be tested (in automated mode) for Ubuntu, QNX, AGL. It is the Project Maintainer responsibility to certify solution for all referenced platforms.
 
-### Vesions of platforms
+### Versions of platforms
 
-This proposal is aboud certifying SDL fol latest releases of Ubuntu, QNX, AGL. 
-Newer releases of referenced platforms will probably require new proposal in case. 
+This proposal is about certifying SDL for the latest releases of Ubuntu, QNX, AGL. 
+Future releases of referenced platforms will require new SDL-evolution proposal.
 
-### SDL compilation process :
+### SDL compilation process:
 
 #### Compilation for QNX 7.0
 
-Compilation for QNX 7.0 required preinstalled QXN7.0 SDP on developers worstation.
+Compilation for QNX 7.0 required pre-installed QXN7.0 SDP on developer workstation.
 
-SDL will contains QNX 7.0 toolchain file that should be used for compilaiton. 
+SDL will contains QNX 7.0 toolchain file that should be used for compilation. 
 Example : 
 
 ```$ cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>```
@@ -64,36 +63,36 @@ Then all binaries and libraries required for running SDL on QNX will be in `<bui
 
 #### Compilation for AGL 
 
-Compilation for AGL required preinstalled AGL SDK in developers platfrom. 
-Compilation for AGL is not cross platform compilaiton, but specific versions of libraries should be guaranteed.
+Compilation for AGL required pre-installed AGL SDK on the developer platform. 
+Compilation for AGL is not cross platform compilation, but specific versions of libraries should be guaranteed.
 
 SDL will contains Docker file with environment ready for compilation for **AGL Flounder 6.0.2**.
-Default command of this docekr file will be `cmake && make install` commands that will compile sdl code.
-Before runing compilation in container developer should specify source directory of sdl code.
+Default command for this Docker file will be `cmake && make install` commands that will compile SDL Core code.
+Before running compilation in container developer should specify source directory of SDL Core code.
 
-So compilation of SDL code for AGL will be done with docker file
+Compilation of SDL code for AGL will be done by using docker file.
 ```
 $ docker build -t agl_compile .
 $ docker run -v <sdl_core>:/home/developer/sdl agl_compile
 ```
-Then all binaries and libraries required for running SDL on AGL will be in `<sdl_core>/build/bin`
+Then all binaries and libraries, which are required for running SDL Core on the AGL platform will be stored in `<sdl_core>/build/bin`
 
 ### SDL runtime dependencies
 
 SDL has the following runtime dependencies:
- - libpthread
- - libdl
- - libcrypto.so
- - libssl.so
- - libcrypt.so
- - libstdc++.so
- - libc.so
- - libgcc_s.so
- - libudev.so
- - libsqlite3.so
- - librt.so
+ - libpthread;
+ - libdl;
+ - libcrypto.so;
+ - libssl.so;
+ - libcrypt.so;
+ - libstdc++.so;
+ - libc.so;
+ - libgcc_s.so;
+ - libudev.so;
+ - libsqlite3.so;
+ - librt.so.
 
-These libraries should be ported and pre-installed on the target platform before running SDL.
+These libraries should be ported and pre-installed on the distributed target platform before running SDL.
 
 #### Modification in Utils component
 
@@ -103,7 +102,7 @@ Utils component provides all SDL layers platform agnostic interface for communic
  - threads and sync primitives;
  - timers;
  - logging;
- - system resource collecting;
+ - system resource collecting.
 
 ### Provide ability for automated testing 
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -9,36 +9,36 @@
 
 ## Introduction
 
-This proposal is about expanding the list of officially supported platforms by SDL with the following the operation systems:
+This proposal is about expanding the list of officially certified platforms by SDL with the following the operation systems:
 
  - QNX 7.0 (x64)
  - Automotive Grade Linux (AGL) Flounder 6.0.2 (x64)
 
 And approach for cross-platform testing automation.
 
-SDL source code should be compilabe for flowing platforms:
+SDL source code should be compilable for the following platforms:
 
  - Ubuntu - 16.04 (x64) default
  - QNX - 7.0 (x64)
  - Automotive Grade Linux - Flounder 6.0.2 (x64)
 
-Platform specific code should be isolated and should not contain any business logic. SDL sources should not contain code code duplication for specific platform. SDL should not contain special pre-compiled binaries for specific platform.
+Platform specific code should be isolated and should not contain any business logic. SDL sources should not contain code duplication for specific platform. SDL should not contain special pre-compiled binaries for specific platform.
 
 ## Motivation
 
 **QNX 6.5** (currently supported by SDL) is already out of date. New version of QNX released is QNX7.0.  
 
-**QNX 7.0** is widely used by OEM manufactures, so SDL should support building and working on QNX7.0. 
+**QNX 7.0** is widely used by OEM manufactures, so SDL should be ready to be certified for working on QNX7.0. 
 
-**Automotive Grade Linux (AGL)** is modern and popular Linux platform for the Automotive industry, and it is already used by many car manufacturers. SDL should also be ported to this platform and tested on it. 
+**Automotive Grade Linux (AGL)** is modern and popular Linux platform for the Automotive industry, and it is already used by many car manufacturers. SDL should also be ready to be certified for using this platform and tested on it. 
 
 ## Proposed solution
 
-Support open source SDL compilation for 3 platforms :
+Provide readiness for open source SDL compilation and certification by SDL Steering Committee for 3 platforms :
 
- - Ubuntu 16.04 x64 (or higher) native 
- - QNX 7.0 x64 (Using SDL on virtual workstation)
- - Automotive Grade Linux x64 (Using SDL on virtual workstation)
+ - Ubuntu 16.04 x64 (or higher) native. 
+ - QNX 7.0 x64 (Using SDL on virtual workstation).
+ - Automotive Grade Linux x64 (Using SDL on virtual workstation).
 
 ### Rework of SDL code 
 
@@ -57,56 +57,56 @@ SDL may use modern cmake approach for targets creation. It will simplify porting
 
 ###### Use CMake name spaces 
 
-Propose to use cmake with namespaces for all SDL components and dependencies. 
+Propose to use cmake with name spaces for all SDL components and dependencies. 
 This best practice of cmake allow:
- - make clear components dependencies
- - avoid dependency gaps (required for multi-threading compilation).
- - Keep components independent
- - Undestand components interface
- - Unificate external dependencies managment 
+ - To make clear components dependencies;
+ - To avoid dependency gaps (required for multi-threading compilation);
+ - To keep components independent;
+ - To understand components interface;
+ - To unify external dependencies management.
  
 Here are the drawbacks of the current structure of cmake usage:
 1. Existing cmake structure does not allow easy and seamless integration to other operating systems.
 2. Existing cmake structure has no unified management system of 3rd party libraries.
 3. With existing cmake structure we have problems with components and libraries dependencies, and the modern approach should resolve it.
-4. This New approach will make cmake files more clear and lightweight.
+4. This new approach will make cmake files more clear and lightweight.
 
 
 ###### target_<link_libraries,include_directiries>
 
-SDL CMake files should avoid using global cmake commands for adding compiler flags, include dirrectories, linkage libraries, etc ...
+SDL CMake files should avoid using global cmake commands for adding compiler flags, include directories, linkage libraries, etc ...
 
-This functions polute the project compilation structure, adds hidden dependencies between components, and make cmake files unclear and confusing.
+This functions pollute the project compilation structure, adds hidden dependencies between components, and make cmake files unclear and confusing.
 
-SDL CMake files should explicitely specify include directiries, link libraries, compiler options for entire target that it compiles.
+SDL CMake files should explicitly specify include directories, link libraries, compiler options for entire target that it compiles.
 
 #### 3rd party libraries for new platforms
 
-File .cmake should be created for each third party library used by SDL. This file will expose the library as cmake_library.
+File .cmake should be created for each 3rd party library used by SDL. This file will expose the library as cmake_library.
 
-All following third party libraries compiled within SDL should be configured for QNX7 and AGL x86 platforms:
-  - boost
-  - libapr
-  - libaprutils
-  - liblog4cxx
-  - bson-clib
-  - json
+The following 3rd party libraries which were compiled within SDL, should be configured for QNX7 and AGL x86 platforms:
+  - boost;
+  - libapr;
+  - libaprutils;
+  - liblog4cxx;
+  - bson-clib;
+  - json.
 
 #### New Cmake approach detailed design 
 
 ##### SDL core repository structure:
 
- - `/CMakeLists.txt` : Contains common build configs for all projects, include directories with some buils utils and helters.
- - `/src/` : Contains all sources of the project
- - `/src/components` : contains sources of components of SmartDeviceLinkCore
- - `/src/3rd_party` : contains sources of 3rd party components
- - `/src/appMain` : contains sources of main executable of SmartDeviceLinkCore and config files for runtime
- - `/src/docs/` : contains doxygen template for SDD generation.
- - `/src/tools/` : contains tools for work with repository, helpers, formatters, git hooks, etc ...
- - `/cmake` : contains addtitional cmake files with common code across components
- - `/cmake/toolchains` : contains compilation toolchains for different platforms
- - `/cmake/helpers` : contains cmake helpers with common code across components
- - `/cmake/dependencies` : contains cmake file for finding certain dependency on the system
+ - `/CMakeLists.txt`: contains common build configs for all projects, include directories with some builds utils and helpers;
+ - `/src/`: contains all sources of the project;
+ - `/src/components`: contains sources of SDL Core components;
+ - `/src/3rd_party`: contains sources of 3rd party components;
+ - `/src/appMain`: contains sources of SDL Core main executable and config files for runtime;
+ - `/src/docs/`: contains doxygen template for Software Detailed Design (SDD) document generation;
+ - `/src/tools/`: contains tools for work with repository, helpers, formatters, git hooks, etc;
+ - `/cmake`: contains additional cmake files with common code across components;
+ - `/cmake/toolchains`: contains compilation toolchains for different platforms;
+ - `/cmake/helpers`: contains cmake helpers with common code across components;
+ - `/cmake/dependencies`: contains cmake file for finding certain dependency on the system.
 
 Each folder should contain a README file with descriptions of contents and examples of usage if applicable.
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -187,7 +187,8 @@ This layer includes:
 
 ## Potential downsides
 
-N/A
+* Compilation for additional platfroms requires tricky changes in configuration and build files.
+* Futher changes of configuration or build files may breake ability to build SDL for QNX or AGL. 
 
 ## Impact on existing code
 
@@ -196,22 +197,14 @@ All components that use **utils** will be affected and need to be retested on th
  
 ## Alternatives considered
 
+#### Refactor cmake structure for easy multiple platforms support 
+Current approach for creating cmake files and mamaging dependencies have folowing problems : 
 
-#### Additional transport support on AGL, QNX virtual workstation
+1. Existing cmake structure does not allow easy and seamless integration to other operating systems.
+2. Existing cmake structure has no unified management system of 3rd party libraries.
+3. With existing cmake structure we have problems with components and libraries dependencies.
 
-Add USB and Bluetooth transport support for virtualized QNX and AGL platforms.
-These transport adapters will not be used for real OEMs, the only place to use them will be virtual workstations.
-Also communication via this transport adapters actually will be emulated by virtual workstation.
-Supporting of additional transports on the virtual workstation is exhausted. There is no valuable reason to keep supporting of many transports on multiple platforms. One exception might be applied - as best practice example for OEM suppliers. 
-
-Pros: 
- - Testing may be done via additional transports.
-
-Cons:
-- Big efforts for automation of transport testing. 
-- Big efforts for supporting many transports on multiple platform.
-- Transport specific code will not be actual for OEM suppliers.
-- Transport testing will be executed through virtualisation layer.
+Unificaiton of 3rd party libraries managment and internal dependencies management would reduce OEM efforts to integrate SDL into the custom OEM environment. 
 
 #### Using real hardware with QNX and AGL
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -14,20 +14,30 @@ This proposal is about expanding the list of officially certified platforms by S
  - QNX 7.0 (x64)
  - Automotive Grade Linux (AGL) Flounder 6.0.2 (x64)
 
-The next part of this proposal is an approach for cross-platform testing automation.
+In order to certify the above platforms for SDL, automation testing need to be created for additional platforms.
 
-SDL source code should be compilable on the following platforms:
+In order to create automation testing for additional platforms we need to make folowing changes :
+
+1. SDL source code should be compilable on the following platforms:
 
  - Ubuntu - 16.04 (x64) default
  - QNX - 7.0 (x64)
  - Automotive Grade Linux - Flounder 6.0.2 (x64)
 
-The following conditions must be matched: 
+2. The following conditions must be matched: 
 - Platform specific code should be isolated and should not contain any business logic. 
 - SDL sources should not contain code duplication for specific platform.
 - SDL should not contain special pre-compiled binaries for specific platform.
 
 ## Motivation
+
+POSIX complience supposed to complience for any POSIX based system. 
+But this is not true. 
+Intergation of SDL to any POSIX based operation system (AGL or QNX) requires significat rework of sdl code.
+
+POSIX complience des not means QNX complience. 
+POSIX complience is not enought for  certificatation leads to bugs when we integrate to production platform and we want to minimize incompatibilities 
+
 
 **QNX 6.5** (currently supported by SDL) is already out of date. New version of QNX released is QNX7.0.  
 
@@ -38,8 +48,7 @@ The following conditions must be matched:
 
 ## Proposed solution
 
-Provide readiness for open source SDL compilation and certification by SDL Steering Committee for 3 platforms:
-
+Without modifications SDL source code should be ready to be compiled for for 3 platforms:
  - Ubuntu 16.04 x64 (or higher) native 
  - QNX 7.0 x64 (Using SDL on virtual workstation)
  - Automotive Grade Linux x64 (Using SDL on virtual workstation)
@@ -49,7 +58,7 @@ It is the Project Maintainer responsibility to certify solution for all referenc
 
 ### Versions of platforms
 
-This proposal is about certifying of the current stable releases of Ubuntu, QNX, AGL for SDL to work on these platforms. 
+This proposal is about certifying of the current long term supported releases of Ubuntu, QNX, AGL for SDL to work on these platforms. 
 
 Current stable releases at the moment of proposal creation are: 
  - Ubuntu - 16.04 (x64) default
@@ -59,6 +68,8 @@ Current stable releases at the moment of proposal creation are:
 Future releases of referenced platforms will require new SDL-evolution proposal.
 
 ### SDL compilation process:
+
+As part of this proposal we are *recomending* the folowing compilation process : 
 
 #### Compilation for QNX 7.0
 
@@ -122,13 +133,17 @@ These libraries should be ported and pre-installed on the distributed target pla
 
 #### Modification in Utils component
 
-Utils component will be affected by modification of SDL Core providing ability to pass SDLC certification. 
+Utils component will be affected by modification of SDL Core providing ability to pass SDLC certification.
+
 Utils component provides all SDL layers platform agnostic interface for communication with the operation system:
  - file system operations;
  - threads and sync primitives;
  - timers;
  - logging;
  - system resource collecting.
+ 
+ Currently Utils component is platform agnostic but it may require some minor modificaiton in scope of copilation for QNX anf AGL.
+ 
 
 ### Provide ability for automated testing 
 
@@ -154,7 +169,7 @@ The following items should be checked for all these platforms:
  - Compilation;
  - Unit tests;
  - Automated smoke tests;
- - Existing features automated test cases (in case if feature is applicable on the virtual workstation).  
+ - Existing features automated test cases (in case if feature is applicable on the [virtual workstation](https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md)). 
 
 SDL can be tested on virtual workstation for each mentioned platform.  
 **Only** Transmission Control Protocol (TCP) transport will be used for communication with mobile.  
@@ -197,8 +212,11 @@ This layer includes:
 
 ## Potential downsides
 
-* Compilation for additional platforms requires tricky changes in configuration and build files.
-* Further changes of configuration or build files may break the ability to build SDL for QNX or AGL. 
+Compilation for additional platforms requires changes in configuration and build files.
+
+Further changes of configuration or build files may break the ability to build SDL for QNX or AGL. 
+
+SDL developer should keep in mind that code and dependencies should be compiled for different platforms during changing configuration build files. 
 
 ## Impact on existing code
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -1,0 +1,288 @@
+
+
+# Porting SDL to QNX700 and Automotive Grade Linux (AGL) x64 platforms
+
+* Proposal: [SDL-NNNN](nnnn-sdl_on_qnx_700.md)
+* Author: [Alexander Kutsan](https://github.com/LuxoftAKutsan)
+* Status: **Awaiting review**
+* Impacted Platforms: [Core, ATF]
+
+## Introduction
+
+This proposal is about expanding the list of officially supported platforms by SDL with the following the operation systems:
+
+ - QNX 7.0 (x64)
+ - Automotive Grade Linux (AGL) Flounder 6.0.2 (x64)
+
+And approach for cross-platform testing automation.
+
+SDL source code should be compilabe for flowing platforms:
+
+ - Ubuntu - 16.04 (x64) default
+ - QNX - 7.0 (x64)
+ - Automotive Grade Linux - Flounder 6.0.2 (x64)
+
+Platform specific code should be isolated and should not contain any business logic. SDL sources should not contain code code duplication for specific platform. SDL should not contain special pre-compiled binaries for specific platform.
+
+## Motivation
+
+**QNX 6.5** (currently supported by SDL) is already out of date. New version of QNX released is QNX7.0.  
+
+**QNX 7.0** is widely used by OEM manufactures, so SDL should support building and working on QNX7.0. 
+
+**Automotive Grade Linux (AGL)** is modern and popular Linux platform for the Automotive industry, and it is already used by many car manufacturers. SDL should also be ported to this platform and tested on it. 
+
+## Proposed solution
+
+Support open source SDL compilation for 3 platforms :
+
+ - Ubuntu 16.04 x64 (or higher) native 
+ - QNX 7.0 x64 (Using SDL on virtual workstation)
+ - Automotive Grade Linux x64 (Using SDL on virtual workstation)
+
+### Rework of SDL code 
+
+Cmake toolchain mechanism should be used for changing target platforms.
+
+ **Example** :
+  - Compilation for QNX : `cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>` 
+  - Compilation for AGL : `cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_AGL_x86.cmake <sdl_core>` 
+
+#### Refactoring of cmake structure
+
+
+##### CMake modern approach
+
+SDL may use modern cmake approach for targets creation. It will simplify porting SDL to any platform.  
+
+###### Use CMake name spaces 
+
+Propose to use cmake with namespaces for all SDL components and dependencies. 
+This best practice of cmake allow:
+ - make clear components dependencies
+ - avoid dependency gaps (required for multi-threading compilation).
+ - Keep components independent
+ - Undestand components interface
+ - Unificate external dependencies managment 
+ 
+Here are the drawbacks of the current structure of cmake usage:
+1. Existing cmake structure does not allow easy and seamless integration to other operating systems.
+2. Existing cmake structure has no unified management system of 3rd party libraries.
+3. With existing cmake structure we have problems with components and libraries dependencies, and the modern approach should resolve it.
+4. This New approach will make cmake files more clear and lightweight.
+
+
+###### target_<link_libraries,include_directiries>
+
+SDL CMake files should avoid using global cmake commands for adding compiler flags, include dirrectories, linkage libraries, etc ...
+
+This functions polute the project compilation structure, adds hidden dependencies between components, and make cmake files unclear and confusing.
+
+SDL CMake files should explicitely specify include directiries, link libraries, compiler options for entire target that it compiles.
+
+#### 3rd party libraries for new platforms
+
+File .cmake should be created for each third party library used by SDL. This file will expose the library as cmake_library.
+
+All following third party libraries compiled within SDL should be configured for QNX7 and AGL x86 platforms:
+  - boost
+  - libapr
+  - libaprutils
+  - liblog4cxx
+  - bson-clib
+  - json
+
+#### New Cmake approach detailed design 
+
+##### SDL core repository structure:
+
+ - `/CMakeLists.txt` : Contains common build configs for all projects, include directories with some buils utils and helters.
+ - `/src/` : Contains all sources of the project
+ - `/src/components` : contains sources of components of SmartDeviceLinkCore
+ - `/src/3rd_party` : contains sources of 3rd party components
+ - `/src/appMain` : contains sources of main executable of SmartDeviceLinkCore and config files for runtime
+ - `/src/docs/` : contains doxygen template for SDD generation.
+ - `/src/tools/` : contains tools for work with repository, helpers, formatters, git hooks, etc ...
+ - `/cmake` : contains addtitional cmake files with common code across components
+ - `/cmake/toolchains` : contains compilation toolchains for different platforms
+ - `/cmake/helpers` : contains cmake helpers with common code across components
+ - `/cmake/dependencies` : contains cmake file for finding certain dependency on the system
+
+Each folder should contain a README file with descriptions of contents and examples of usage if applicable.
+
+##### 3rd party libraries managment:
+
+By default build system should not install to the system any additional libraries during compilation. 
+
+If required version of certain dependency is available on the system, build system should use it.
+
+If required version of certain dependency missed on the system, it build system should compile it and keep in `<build>` folder within `make` command.
+
+
+**External dependencies** - dependencies that build system should download from official sources during cmake run.
+**3rd_party dependencies** - dependencies that build system should keep as sources in `src/3rd_party` directory.
+
+SDL is responsible for 3rd_party dependencies code and fixes that may also be applied to this code.
+
+List of SDL dependencies : 
+  - boost : **external dependency**, if it was not found on the system, build system should download sources from oficial sources during `cmake` command run and compile within project during `make` command run.
+  - libapr : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+  - libaprutils : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+  - liblog4cxx : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+  - bson-clib : **external dependency**, if it was not found on the system, build system should download sources from oficial sources during `cmake` command run and compile within project during `make` command run.
+  - json : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+
+
+######  3rd party libraries instalation rules
+
+Compilation of libraries should not trigger their instalation to the system by default.
+
+Propose to use special CMAKE variable if user desires to install 3rd party libraries to the system: `THIRD_PARTY_INSTALL_PREFIX`.
+
+If this variable is empty, SDL should install 3rd party and external dependencies libraries to `{BUILD_DIR}`/compile_dependencies
+
+During `make install` SDL should copy all files required for SDL RUN to `{BUILD_DIR}`/bin, and libraries required for sdl run to `{BUILD_DIR}`/bin/lib.
+
+
+#### SDL runtime dependencies
+
+SDL has the following runtime dependencies:
+```
+$ ldd smartDeviceLink
+    linux-vdso.so.1 (0x00007ffdbf543000)
+    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb77f45f000)
+    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fb77f25b000)
+    libbluetooth.so.3 => /usr/lib/x86_64-linux-gnu/libbluetooth.so.3 (0x00007fb77f038000)
+    libusb-1.0.so.0 => /lib/x86_64-linux-gnu/libusb-1.0.so.0 (0x00007fb77ee20000)
+    libPolicy.so (0x00007fb77e062000)
+    libcrypto.so.1.0.0 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007fb77dc1f000)
+    libssl.so.1.0.0 => /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007fb77d9b7000)
+    libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fb77d1ed000)
+    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fb77cfd5000)
+    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb77cbe4000)
+    /lib64/ld-linux-x86-64.so.2 (0x00007fb78220b000)
+    libudev.so.1 => /lib/x86_64-linux-gnu/libudev.so.1 (0x00007fb77c9c6000)
+    libsqlite3.so.0 => /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 (0x00007fb77c294000)
+    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fb77bef6000)
+    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fb77bcee000)
+    libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007fb77b882000)
+```
+These libraries should be ported and pre-installed on the distribution of the target platform before running SDL.
+
+#### Modify Utils component
+
+Utils component will be affected with porting SDL to new platforms. 
+Utils component provides all SDL layers platform agnostic interface for communication with the operation system:
+ - file system operations
+ - threads and sync primitives
+ - timers
+ - logging
+ - system resource collecting
+ - ... 
+ 
+### Provide Ability for automated testing 
+
+Existing automated testing tool [sdl_atf](https://github.com/smartdevicelink/sdl_atf) and 
+[scripts](https://github.com/smartdevicelink/sdl_atf_test_scripts)
+should be used for checking SDL functionality on the new platform.
+
+#### Modification in sdl_atf
+
+sdl_atf tool should be executed on host workstation, but SDL will be executed on remote virtual workstation. 
+
+For support remote automated testing of SDL, the following proposal should be implemented: https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md
+
+#### Modification in test scripts
+
+Some scripts should be modified to use SDL on remote workstation.  
+All operations with SDL files ( hmi_capabilities, preloaded_pt, etc ...) should be covered with wrappers that support either local or remote execution. 
+
+
+## Testing Approach
+
+The following items should be checked for all these platforms :
+ 
+ - Compilation
+ - Unit tests
+ - Automated smoke
+ - Existing features automated test cases (in case if feature is applicable on the virtual workstation)  
+
+SDL will be tested on virtual workstation for each supported platform. 
+For communication with mobile will be used **only** TCP transport.
+For communication with HMI will be used TCP/WebSockets transport.
+
+All supported platforms (Ubuntu, AGL, QNX) will share codebase for communication with mobile and HMI.  
+
+#### Manual testing
+
+Manual testing will be performed using WebHMI https://github.com/smartdevicelink/sdl_hmi
+No changes in WebHMI are expected, and WebHMI will be executed on a real developer workstation.
+
+Mobile application may be connected to SDL via TCP.
+
+### Automated testing.
+
+With some changes in ATF test framework and existing scripts SDL will be tested automatically on all 3 platforms. 
+
+The same test scripts will be executed for : 
+ - Ubuntu 
+ - AGL
+ - QNX
+ 
+Test coverage will include:
+  - smoke testing of SDL (basic SDL scenarios and 3 policy flows) 
+  - all delivered features that are applicable for cross platform testing.
+  
+Each further delivered feature should be tested on all supported platforms.
+
+#### Missed functionality on AGL and QNX
+
+Open source SDL will no implement platform specific functionality on all supported systems.
+It is OEM's responcibility to implement and check platform specific layer of SDL - OEM Adapter. 
+
+This layer includes :
+ - USB transport
+ - Bluetooth transport
+ - Multiple transports support.
+
+
+## Potential downsides
+
+N/A
+
+## Impact on existing code
+
+SDL core will be modified in platform specific places.
+All components that use **utils** will be affected and need to be retested on target platform.
+ 
+## Alternatives considered
+
+
+#### Additional transport support on AGL, QNX virtual workstation
+
+Add USB and Bluetooth transport support for virtualized QNX and AGL platforms.
+These transport adapters will not be used for real OEMs, the only place to use them will be virtual workstations.
+Also communication via this transport adapters actually will be emulated by virtual workstation.
+Supporting of additional transports on virtual workstation is exhausted. There is no valuable reason to keep supporting many transports on multiple platforms except as best practice example for OEM suppliers. 
+
+Pros : 
+ - Testing may be done via additional transports
+
+Cons:
+- Big efforts for automation of transport testing 
+- Big efforts for supporting many transports on multiple platform
+- Transport specific code will not be actual for OEM suppliers
+- Transport testing will be executed through virtualisation layer.
+
+#### Using real hardware with QNX and AGL
+
+SDL may not be tested on virtual workstation, but on real hardware with QNX, Ubuntu and AGL.
+
+Pros : 
+ - Real USB, Bluetooth transports may be used for testing.
+
+Cons :
+ - This approach will introduce additional efforts for resolving hardware specific problems. 
+ - Each OEM supplier has its own hardware, and hardware specific code will be partially not actual.
+ - SDL contributor will need to have real hardware (same as certified by SDL) to test their fixes and implementation.
+ - Exhausted automation of transport testing. Automation pipelines should use real hardware that requires additional efforts for tuning.

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -110,7 +110,7 @@ The following 3rd party libraries which were compiled within SDL, should be conf
 
 Each folder should contain a README file with descriptions of contents and examples of usage if applicable.
 
-##### 3rd party libraries managment:
+##### 3rd party libraries management:
 
 By default build system should not install to the system any additional libraries during compilation. 
 
@@ -120,28 +120,28 @@ If required version of certain dependency missed on the system, it build system 
 
 
 **External dependencies** - dependencies that build system should download from official sources during cmake run.
-**3rd_party dependencies** - dependencies that build system should keep as sources in `src/3rd_party` directory.
+**3rd party dependencies** - dependencies that build system should keep as sources in `src/3rd_party` directory.
 
-SDL is responsible for 3rd_party dependencies code and fixes that may also be applied to this code.
+SDL is responsible for 3rd party dependencies in the code and fixes that may also be applied to this code.
 
-List of SDL dependencies : 
-  - boost : **external dependency**, if it was not found on the system, build system should download sources from oficial sources during `cmake` command run and compile within project during `make` command run.
-  - libapr : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
-  - libaprutils : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
-  - liblog4cxx : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
-  - bson-clib : **external dependency**, if it was not found on the system, build system should download sources from oficial sources during `cmake` command run and compile within project during `make` command run.
-  - json : **3rd_party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+The list of SDL dependencies : 
+  - boost : **external dependency**, if it was not found on the system, build system should download sources from official sources during `cmake` command run and compile within project during `make` command run.
+  - libapr : **3rd party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+  - libaprutils : **3rd party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+  - liblog4cxx : **3rd party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
+  - bson-clib : **external dependency**, if it was not found on the system, build system should download sources from official sources during `cmake` command run and compile within project during `make` command run.
+  - json : **3rd party dependency**, if it was not found on the system, build system should take sources from `src/3rd_party/` and compile within project during `make` command run.
 
 
-######  3rd party libraries instalation rules
+######  3rd party libraries installation rules
 
-Compilation of libraries should not trigger their instalation to the system by default.
+Compilation of libraries should not trigger their installation to the system by default.
 
 Propose to use special CMAKE variable if user desires to install 3rd party libraries to the system: `THIRD_PARTY_INSTALL_PREFIX`.
 
 If this variable is empty, SDL should install 3rd party and external dependencies libraries to `{BUILD_DIR}`/compile_dependencies
 
-During `make install` SDL should copy all files required for SDL RUN to `{BUILD_DIR}`/bin, and libraries required for sdl run to `{BUILD_DIR}`/bin/lib.
+During `make install` SDL should copy all files required for SDL RUN to `{BUILD_DIR}`/bin, and libraries required for SDL RUN to `{BUILD_DIR}`/bin/lib.
 
 
 #### SDL runtime dependencies
@@ -167,32 +167,31 @@ $ ldd smartDeviceLink
     librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fb77bcee000)
     libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007fb77b882000)
 ```
-These libraries should be ported and pre-installed on the distribution of the target platform before running SDL.
+These libraries should be ported and pre-installed on the distributed target platform before running SDL.
 
 #### Modify Utils component
 
-Utils component will be affected with porting SDL to new platforms. 
+Utils component will be affected by modification of SDL Core to providing ability to pass SDLC certification. 
 Utils component provides all SDL layers platform agnostic interface for communication with the operation system:
- - file system operations
- - threads and sync primitives
- - timers
- - logging
- - system resource collecting
- - ... 
+ - file system operations;
+ - threads and sync primitives;
+ - timers;
+ - logging;
+ - system resource collecting.
  
-### Provide Ability for automated testing 
+### Provide ability for automated testing 
 
 Existing automated testing tool [sdl_atf](https://github.com/smartdevicelink/sdl_atf) and 
 [scripts](https://github.com/smartdevicelink/sdl_atf_test_scripts)
-should be used for checking SDL functionality on the new platform.
+should be used for checking SDL functionality on the new platforms.
 
-#### Modification in sdl_atf
+#### Modifications in ATF
 
-sdl_atf tool should be executed on host workstation, but SDL will be executed on remote virtual workstation. 
+sdl_atf tool should be executed on host workstation, but SDL will be ran on remote virtual workstation. 
 
 For support remote automated testing of SDL, the following proposal should be implemented: https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md
 
-#### Modification in test scripts
+#### Modifications in the test scripts
 
 Some scripts should be modified to use SDL on remote workstation.  
 All operations with SDL files ( hmi_capabilities, preloaded_pt, etc ...) should be covered with wrappers that support either local or remote execution. 
@@ -200,49 +199,49 @@ All operations with SDL files ( hmi_capabilities, preloaded_pt, etc ...) should 
 
 ## Testing Approach
 
-The following items should be checked for all these platforms :
+The following items should be checked for all these platforms:
  
- - Compilation
- - Unit tests
- - Automated smoke
- - Existing features automated test cases (in case if feature is applicable on the virtual workstation)  
+ - Compilation;
+ - Unit tests;
+ - Automated smoke;
+ - Existing features automated test cases (in case if feature is applicable on the virtual workstation).  
 
-SDL will be tested on virtual workstation for each supported platform. 
-For communication with mobile will be used **only** TCP transport.
+SDL could be tested on virtual workstation for each mentioned platform. 
+For communication with mobile will be used **only**  Transmission Control Protocol (TCP) transport.
 For communication with HMI will be used TCP/WebSockets transport.
 
-All supported platforms (Ubuntu, AGL, QNX) will share codebase for communication with mobile and HMI.  
+All mentioned platforms (Ubuntu, AGL, QNX) will share codebase for communication with mobile and HMI.  
 
 #### Manual testing
 
 Manual testing will be performed using WebHMI https://github.com/smartdevicelink/sdl_hmi
-No changes in WebHMI are expected, and WebHMI will be executed on a real developer workstation.
+No changes in WebHMI are expected, and WebHMI will be executed on the real developer workstation.
 
-Mobile application may be connected to SDL via TCP.
+Mobile application may be connected to SDL Core via TCP.
 
 ### Automated testing.
 
-With some changes in ATF test framework and existing scripts SDL will be tested automatically on all 3 platforms. 
+With some changes in ATF test framework and existing scripts SDL Core could be tested automatically on all 3 platforms. 
 
-The same test scripts will be executed for : 
- - Ubuntu 
- - AGL
- - QNX
+The same test scripts will be executed for: 
+ - Ubuntu;
+ - AGL;
+ - QNX.
  
 Test coverage will include:
-  - smoke testing of SDL (basic SDL scenarios and 3 policy flows) 
+  - smoke testing of SDL Core (basic SDL scenarios and 3 policy flows (HTTP, PROPRIETARY, EXTERNAL_PROPRIETARY)); 
   - all delivered features that are applicable for cross platform testing.
   
-Each further delivered feature should be tested on all supported platforms.
+Each further delivered feature should be tested on all mentioned platforms.
 
 #### Missed functionality on AGL and QNX
 
-Open source SDL will no implement platform specific functionality on all supported systems.
-It is OEM's responcibility to implement and check platform specific layer of SDL - OEM Adapter. 
+Open source SDL will no implement platform specific functionality on all mentioned systems.
+It is OEM's responsibility to implement and check platform specific layer of SDL - OEM Adapter. 
 
-This layer includes :
- - USB transport
- - Bluetooth transport
+This layer includes:
+ - USB transport;
+ - Bluetooth transport;
  - Multiple transports support.
 
 
@@ -252,8 +251,8 @@ N/A
 
 ## Impact on existing code
 
-SDL core will be modified in platform specific places.
-All components that use **utils** will be affected and need to be retested on target platform.
+SDL core will be modified in the platform specific places.
+All components that use **utils** will be affected and need to be retested on the target platform.
  
 ## Alternatives considered
 
@@ -263,26 +262,26 @@ All components that use **utils** will be affected and need to be retested on ta
 Add USB and Bluetooth transport support for virtualized QNX and AGL platforms.
 These transport adapters will not be used for real OEMs, the only place to use them will be virtual workstations.
 Also communication via this transport adapters actually will be emulated by virtual workstation.
-Supporting of additional transports on virtual workstation is exhausted. There is no valuable reason to keep supporting many transports on multiple platforms except as best practice example for OEM suppliers. 
+Supporting of additional transports on the virtual workstation is exhausted. There is no valuable reason to keep supporting of many transports on multiple platforms. One exception might be applied - as best practice example for OEM suppliers. 
 
-Pros : 
- - Testing may be done via additional transports
+Pros: 
+ - Testing may be done via additional transports.
 
 Cons:
-- Big efforts for automation of transport testing 
-- Big efforts for supporting many transports on multiple platform
-- Transport specific code will not be actual for OEM suppliers
+- Big efforts for automation of transport testing. 
+- Big efforts for supporting many transports on multiple platform.
+- Transport specific code will not be actual for OEM suppliers.
 - Transport testing will be executed through virtualisation layer.
 
 #### Using real hardware with QNX and AGL
 
 SDL may not be tested on virtual workstation, but on real hardware with QNX, Ubuntu and AGL.
 
-Pros : 
+Pros: 
  - Real USB, Bluetooth transports may be used for testing.
 
-Cons :
+Cons:
  - This approach will introduce additional efforts for resolving hardware specific problems. 
  - Each OEM supplier has its own hardware, and hardware specific code will be partially not actual.
  - SDL contributor will need to have real hardware (same as certified by SDL) to test their fixes and implementation.
- - Exhausted automation of transport testing. Automation pipelines should use real hardware that requires additional efforts for tuning.
+ - Exhausted process of automation for transport-specific testing. Automation pipelines should use real hardware that requires additional efforts for tuning.

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -31,9 +31,10 @@ In order to create automation testing for additional platforms we need to make f
 
 ## Motivation
 
-POSIX complience supposed to complience for any POSIX based system. 
-But this is not true. 
-Intergation of SDL to any POSIX based operation system (AGL or QNX) requires significat rework of sdl code.
+POSIX (Portable Operating System Interface for Unix) is simply a set of standards that define how to develop programs for UNIX (and its variants). Being POSIX-compliant for an OS means that it supports those standards (e.g., APIs), and thus can either natively run UNIX programs, or at least porting an application from UNIX to the target OS is easy/easier than if it did not support POSIX. 
+
+Integration of SDL to the POSIX-certified (QNX) and mostly POSIX-compliant operation system (AGL) requires significant rework of SDL code.
+This proposal aims to minimize efforts of OEM manufacturers for SDL integration for QNX and AGL.
 
 POSIX complience des not means QNX complience. 
 POSIX complience is not enought for  certificatation leads to bugs when we integrate to production platform and we want to minimize incompatibilities 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -129,7 +129,7 @@ These libraries should be ported and pre-installed on the distributed target pla
 
 #### Modification in Utils component
 
-Utils component will be affected by modification of SDL Core providing ability to pass SDLC certification.
+Utils component will be affected by modification of SDL Core and providing ability to pass SDLC certification.
 
 Utils component provides all SDL layers platform agnostic interface for communication with the operation system:
  - file system operations;
@@ -138,12 +138,12 @@ Utils component provides all SDL layers platform agnostic interface for communic
  - logging;
  - system resource collecting.
  
- Currently Utils component is platform agnostic but it may require some minor modificaiton in scope of copilation for QNX anf AGL.
+ Currently Utils component is platform agnostic but it may require some minor modification in scope of compilation for QNX anf AGL.
  
 
 ### Provide ability for automated testing 
 
-Existing automated testing tool [sdl_atf](https://github.com/smartdevicelink/sdl_atf) and 
+Existing Automated Test Framework (ATF) - [sdl_atf](https://github.com/smartdevicelink/sdl_atf) and 
 [scripts](https://github.com/smartdevicelink/sdl_atf_test_scripts)
 should be used for checking SDL functionality on the new platforms.
 
@@ -151,12 +151,12 @@ should be used for checking SDL functionality on the new platforms.
 
 sdl_atf tool should be executed on host workstation, but SDL will be run on remote virtual workstation. 
 
-For support of SDL remote automated testing, the following proposal should be implemented: https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md
+For support of the SDL remote automated testing, the following proposal should be implemented: https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md
 
 #### Modifications in the test scripts
 
 Some scripts should be modified to use SDL on remote workstation.  
-All operations with SDL files ( hmi_capabilities, preloaded_pt, etc ...) should be covered with wrappers that support either local or remote execution. 
+All operations with SDL files ( hmi_capabilities, Preloaded Policy Table, etc ...) should be covered with wrappers that support either local or remote execution. 
 
 ## Testing Approach
 
@@ -165,7 +165,7 @@ The following items should be checked for all these platforms:
  - Compilation;
  - Unit tests;
  - Automated smoke tests;
- - Existing features automated test cases (in case if feature is applicable on the [virtual workstation](https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md)). 
+ - Automated test cases for validation of the existing features (in case if feature is applicable on the [virtual workstation](https://github.com/LuxoftAKutsan/sdl_evolution/blob/remote_atf_proxy/proposals/nnnn-remote_atf_testing.md)). 
 
 SDL can be tested on virtual workstation for each mentioned platform.  
 **Only** Transmission Control Protocol (TCP) transport will be used for communication with mobile.  
@@ -175,7 +175,7 @@ All mentioned platforms (Ubuntu, AGL, QNX) will share codebase for communication
 
 #### Manual testing
 
-Manual testing will be performed using WebHMI https://github.com/smartdevicelink/sdl_hmi  
+Manual testing will be performed using [WebHMI](https://github.com/smartdevicelink/sdl_hmi).  
 No changes in WebHMI are expected, and WebHMI will be executed on the real developer workstation.
 
 Mobile application may be connected to SDL Core via TCP.
@@ -184,7 +184,7 @@ Mobile application may be connected to SDL Core via TCP.
 
 SDL Core can be tested automatically on all 3 platforms with some changes in ATF test framework and existing scripts. 
 
-The same test scripts will be executed for the following platforms: 
+The same test suite will be executed for the following platforms: 
  - Ubuntu;
  - AGL;
  - QNX.
@@ -208,27 +208,27 @@ This layer includes:
 
 ## Potential downsides
 
-Compilation for additional platforms requires changes in configuration and build files.
+SDL Core compilation for additional platforms requires changes in configuration and build files.
 
 Further changes of configuration or build files may break the ability to build SDL for QNX or AGL. 
 
-SDL developer should keep in mind that code and dependencies should be compiled for different platforms during changing configuration build files. 
+SDL Core developer should keep in mind that code and dependencies should be compiled for different platforms during changing configuration build files. 
 
 ## Impact on existing code
 
 SDL core will be modified in the platform specific places.
-All components that use **utils** will be affected and need to be retested on the target platform.
+All components that use **Utils** will be affected and need to be retested on the target platforms.
  
 ## Alternatives considered
 
 #### Refactor cmake files structure for easy multiple platforms support 
-Current approach for creating cmake files and managing dependencies have the following problems : 
+Current approach for creating cmake files and managing dependencies have the following problems: 
 
 1. Existing cmake structure does not allow easy and seamless integration to other operating systems.
 2. Existing cmake structure has no unified management system of 3rd party libraries.
 3. Existing cmake structure does not allow flexible and clear dependencies resolution between components and libraries.
 
-Unification of 3rd party libraries management and internal dependencies management would reduce OEM efforts to integrate SDL into the custom OEM environment. 
+Unification of 3rd party libraries management and internal dependencies management would reduce OEM efforts to integrate SDL Core into the custom OEM environment. 
 
 #### Using real hardware with QNX and AGL
 

--- a/proposals/nnnn-sdl_on_qnx700_agl.md
+++ b/proposals/nnnn-sdl_on_qnx700_agl.md
@@ -38,11 +38,11 @@ The following conditions must be matched:
 
 ## Proposed solution
 
-Provide readiness for open source SDL compilation and certification by SDL Steering Committee for 3 platforms :
+Provide readiness for open source SDL compilation and certification by SDL Steering Committee for 3 platforms:
 
- - Ubuntu 16.04 x64 (or higher) native. 
- - QNX 7.0 x64 (Using SDL on virtual workstation).
- - Automotive Grade Linux x64 (Using SDL on virtual workstation).
+ - Ubuntu 16.04 x64 (or higher) native 
+ - QNX 7.0 x64 (Using SDL on virtual workstation)
+ - Automotive Grade Linux x64 (Using SDL on virtual workstation)
  
 Within continuous integration each change (Pull Request to develop) to SDL Core should be tested (in automated mode) for Ubuntu, QNX, AGL. 
 It is the Project Maintainer responsibility to certify solution for all referenced platforms.
@@ -64,12 +64,12 @@ Future releases of referenced platforms will require new SDL-evolution proposal.
 
 Compilation for QNX 7.0 requires pre-installed QXN7.0 SDP on developer workstation.
 
-SDL will contain QNX 7.0 toolchain file that should be used for compilation. 
+SDL will contain QNX 7.0 toolchain file that should be used for compilation.  
 Before compilation suggested to setup `THIRD_PARTY_LIBRARY_PATH` variable to avoid instalation of qnx libraries to host system
 
-Example : 
-```$ export THIRD_PARTY_LIBRARY_PATH=<third_party_path>```
-```$ cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>```
+Example:  
+```$ export THIRD_PARTY_LIBRARY_PATH=<third_party_path>```  
+```$ cmake -DCMAKE_TOOLCHAIN_FILE=<sdl_core>/toolchains/Toolchain_QNX700_x86.cmake <sdl_core>```  
 ```$ make install```
 
 Then all binaries and libraries required for SDL run on QNX will be created in `<build_dir>/bin` and <third_party_path>. 
@@ -79,7 +79,7 @@ Then all binaries and libraries required for SDL run on QNX will be created in `
 SDL will contain Docker file with environment ready for qnx compilation. This environment will not contain QNX SDP.
 Before compilation developer should provide path to SDP with directory mounted to container.
 
-Example of compilation with docker : 
+Example of compilation with docker: 
 ```
 $ docker build -t  qnx_sdl_compile .
 $ docker run -v <sdl_core>:/home/developer/sdl \
@@ -156,20 +156,20 @@ The following items should be checked for all these platforms:
  - Automated smoke tests;
  - Existing features automated test cases (in case if feature is applicable on the virtual workstation).  
 
-SDL can be tested on virtual workstation for each mentioned platform. 
-**Only** Transmission Control Protocol (TCP) transport will be used for communication with mobile.
+SDL can be tested on virtual workstation for each mentioned platform.  
+**Only** Transmission Control Protocol (TCP) transport will be used for communication with mobile.  
 TCP/WebSockets transport will be used for communication with HMI.
 
 All mentioned platforms (Ubuntu, AGL, QNX) will share codebase for communication with mobile and HMI.  
 
 #### Manual testing
 
-Manual testing will be performed using WebHMI https://github.com/smartdevicelink/sdl_hmi
+Manual testing will be performed using WebHMI https://github.com/smartdevicelink/sdl_hmi  
 No changes in WebHMI are expected, and WebHMI will be executed on the real developer workstation.
 
 Mobile application may be connected to SDL Core via TCP.
 
-### Automated testing.
+### Automated testing
 
 SDL Core can be tested automatically on all 3 platforms with some changes in ATF test framework and existing scripts. 
 
@@ -198,7 +198,7 @@ This layer includes:
 ## Potential downsides
 
 * Compilation for additional platforms requires tricky changes in configuration and build files.
-* Further changes of configuration or build files may breake ability to build SDL for QNX or AGL. 
+* Further changes of configuration or build files may break the ability to build SDL for QNX or AGL. 
 
 ## Impact on existing code
 
@@ -208,7 +208,7 @@ All components that use **utils** will be affected and need to be retested on th
 ## Alternatives considered
 
 #### Refactor cmake files structure for easy multiple platforms support 
-Current approach for creating cmake files and managing dependencies have the folowing problems : 
+Current approach for creating cmake files and managing dependencies have the following problems : 
 
 1. Existing cmake structure does not allow easy and seamless integration to other operating systems.
 2. Existing cmake structure has no unified management system of 3rd party libraries.


### PR DESCRIPTION
This proposal is about expanding the list of officially certified platforms by SDL with the following operating systems:
 - QNX 7.0 (x64)
 - Automotive Grade Linux (AGL) Flounder 6.0.2 (x64)
In order to certify the above platforms for SDL, automation testing need to be created for additional platforms.
In order to create automation testing for additional platforms we need to make the following changes :
1. SDL source code should be compilable on the following platforms:
 - Ubuntu - 16.04 (x64) default
 - QNX - 7.0 (x64)
 - Automotive Grade Linux - Flounder 6.0.2 (x64)
2. The following conditions must be matched: 
- Platform specific code should be isolated and should not contain any business logic. 
- SDL sources should not contain code duplication for specific platform.
- SDL should not contain special pre-compiled binaries for specific platform.