### PR TITLE
ATF build using CMake

### DIFF
--- a/proposals/nnnn-atf_build_using_cmake.md
+++ b/proposals/nnnn-atf_build_using_cmake.md
@@ -7,17 +7,17 @@
 
 ## Introduction
 
-This proposal offers using cmake build system for compilation ATF project instead of qmake. 
+This proposal offers using of CMake build system for compilation ATF project instead of qmake tool. 
 
 ## Motivation
 
 Extending sdl_atf with new dependencies and new code requires seamless integration with build system.  
 Existing qmake and make systems are not expandable and adding any supplementary components is rather complicated.  
-CMake will be able to provide clear dependency structure, seamless integration with 3rd party libraries, and easy expandable project structure.
+CMake is able to provide clear dependency structure, seamless integration with 3rd party libraries, and easy expandable project structure.
 
 ## Proposed solution
 
-This proposed change is to create CMakeLists.txt with all required dependency descriptions.
+This proposal is about to create CMakeLists.txt files with all required dependency descriptions.
 
 #### Pre build cmake responsibilities:
  - Check if Qt is available
@@ -26,7 +26,7 @@ This proposed change is to create CMakeLists.txt with all required dependency de
 
 #### Build cmake responsibilities:
 
-  - Provide `all` target that will create atf binary
+  - Provide `all` target which will create atf binary
 
   - Provide `install` target that will install required files for running ATF to `CMAKE_INSTALL_PREFIX` variable
 
@@ -37,7 +37,7 @@ N/A
 ## Impact on existing code
 
 The proposal will affect only build system of sdl_atf.  
-Changes may be required in CI configuration, scripts that use ATF, and manuals of ATF usage.
+Changes may be required in Continious Integration system configuration, scripts that use ATF, and manuals of ATF usage.
 
 ## Alternatives considered
 Add extra scripts as workarounds for extending ATF functionality.

--- a/proposals/nnnn-atf_build_using_cmake.md
+++ b/proposals/nnnn-atf_build_using_cmake.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-This proposal offers using of CMake build system for compilation ATF project instead of qmake tool. 
+This proposal offers using CMake build system for compilation ATF project instead of qmake tool. 
 
 ## Motivation
 
@@ -37,7 +37,7 @@ N/A
 ## Impact on existing code
 
 The proposal will affect only build system of sdl_atf.  
-Changes may be required in Continious Integration system configuration, scripts that use ATF, and manuals of ATF usage.
+Changes may be required in Continuous Integration system configuration, scripts that use ATF, and manuals of ATF usage.
 
 ## Alternatives considered
 Add extra scripts as workarounds for extending ATF functionality.

--- a/proposals/nnnn-atf_build_using_cmake.md
+++ b/proposals/nnnn-atf_build_using_cmake.md
@@ -1,0 +1,43 @@
+# ATF build using CMake
+
+* Proposal: [SDL-NNNN](nnnn-atf_build_using_cmake.md)
+* Author: [Alexander Kutsan](https://github.com/LuxoftAKutsan)
+* Status: **Awaiting review**
+* Impacted Platforms: [ATF]
+
+## Introduction
+
+This proposal offers using cmake build system for compilation ATF project instead of qmake. 
+
+## Motivation
+
+Extending sdl_atf with new dependencies and new code requires seamless integration with build system.  
+Existing qmake and make systems are not expandable and adding any supplementary components is rather complicated.  
+CMake will be able to provide clear dependency structure, seamless integration with 3rd party libraries, and easy expandable project structure.
+
+## Proposed solution
+
+This proposed change is to create CMakeLists.txt with all required dependency descriptions.
+
+#### Pre build cmake responsibilities:
+ - Check if Qt is available
+ - Check if lua lib is available
+ - Fetch [bson_c_lib](https://github.com/smartdevicelink/bson_c_lib) with lua support and append it to sdl_atf compilation
+
+#### Build cmake responsibilities:
+
+  - Provide `all` target that will create atf binary
+
+  - Provide `install` target that will install required files for running ATF to `CMAKE_INSTALL_PREFIX` variable
+
+## Potential downsides
+
+N/A
+
+## Impact on existing code
+
+The proposal will affect only build system of sdl_atf.  
+Changes may be required in CI configuration, scripts that use ATF, and manuals of ATF usage.
+
+## Alternatives considered
+Add extra scripts as workarounds for extending ATF functionality.

--- a/proposals/nnnn-atf_build_using_cmake.md
+++ b/proposals/nnnn-atf_build_using_cmake.md
@@ -7,11 +7,11 @@
 
 ## Introduction
 
-This proposal offers using CMake build system for compilation ATF project instead of qmake tool. 
+This proposal offers using CMake build system for compilation Automated Test Framework (ATF) project instead of qmake tool. 
 
 ## Motivation
 
-Extending sdl_atf with new dependencies and new code requires seamless integration with build system.  
+Extending of ATF with new dependencies and new code requires seamless integration with build system.  
 Existing qmake and make systems are not expandable and adding any supplementary components is rather complicated.  
 CMake is able to provide clear dependency structure, seamless integration with 3rd party libraries, and easy expandable project structure.
 
@@ -20,15 +20,15 @@ CMake is able to provide clear dependency structure, seamless integration with 3
 This proposal is about to create CMakeLists.txt files with all required dependency descriptions.
 
 #### Pre build cmake responsibilities:
- - Check if Qt is available
- - Check if lua lib is available
- - Fetch [bson_c_lib](https://github.com/smartdevicelink/bson_c_lib) with lua support and append it to sdl_atf compilation
+ - Check if Qt framework is available on the target workstation.
+ - Check if lua library is available on the target workstation.
+ - Fetch [bson_c_lib](https://github.com/smartdevicelink/bson_c_lib) with lua support and append it to sdl_atf compilation.
 
 #### Build cmake responsibilities:
 
-  - Provide `all` target which will create atf binary
+  - Provide `all` target which will create ATF binary.
 
-  - Provide `install` target that will install required files for running ATF to `CMAKE_INSTALL_PREFIX` variable
+  - Provide `install` target that will install required files for running ATF to `CMAKE_INSTALL_PREFIX` variable.
 
 ## Potential downsides
 


### PR DESCRIPTION
This proposal offers using CMake build system for compilation ATF project instead of qmake tool. 